### PR TITLE
axessibility.sty: add lualatex support

### DIFF
--- a/package/axessibility.sty
+++ b/package/axessibility.sty
@@ -4,22 +4,22 @@
 %%
 %% The original source files were:
 %%
-%% axessibility.dtx 
-%% 
+%% axessibility.dtx
+%%
 %% This is a generated file.
-%% 
+%%
 %%  Copyright (C) 2018, 2019, 2020 by
 %%  Anna Capietto, Sandro Coriasco, Boris Doubrov, Alexander Koslovski,
 %%  Tiziana Armano, Nadir Murru, Dragan Ahmetovic, Cristian Bernareggi
-%% 
+%%
 %%  Based on accsupp and tagpdf
-%% 
+%%
 %%  This work consists of the main source files axessibility.dtx and axessibility.lua,
 %%  and the derived files
 %%    axessibility.ins, axessibility.sty, axessibility.pdf, README,
 %%    axessibilityExampleSingleLineT.tex, axessibilityExampleSingleLineA.tex,
 %% .  axessibilityExampleAlignT.tex, axessibilityExampleAlignA.tex
-%% 
+%%
 %%  This work may be distributed and/or modified under the
 %%  conditions of the LaTeX Project Public License, either version 1.3
 %%  of this license or (at your option) any later version.
@@ -27,12 +27,12 @@
 %%    http://www.latex-project.org/lppl.txt
 %%  and version 1.3 or later is part of all distributions of LaTeX
 %%  version 2005/12/01 or later.
-%% 
+%%
 %%  This work has the LPPL maintenance status `maintained'.
-%% 
+%%
 %%  The Current Maintainer of this work is
 %%                Sandro Coriasco
-%% 
+%%
 
 
 
@@ -345,10 +345,32 @@ require("axessibility.lua")
 
 \RequirePackage{accsupp}
 
+\RequirePackage{ifluatex}
 
 \pdfcompresslevel=0
-\pdfoptionpdfminorversion=6
+
+\ifluatex
+
+    \directlua {
+        if pdf.getminorversion() \string~= 6 then
+            if (status.pdf_gone and status.pdf_gone > 0)
+            or (status.pdf_ptr and status.pdf_ptr > 0)
+            then
+                tex.error("PDF version cannot be changed anymore")
+            else
+                pdf.setminorversion(6)
+            end
+        end
+    }
+
+\else
+
+    \pdfminorversion=6
+
+\fi
+
 \input{glyphtounicode}
+
 \pdfgentounicode=1
 
 


### PR DESCRIPTION
- `\RequirePackage{ifluatex}` in accsupp branch to allow checking whether the used compiler is `lualatex` or not.

- Add a conditional to perform this check, and if lualatex is found to be used, set PDF version to 1.6 via `\directlua`.

- Otherwise, use the more modern `\pdfminorversion` instead of the current (obsolete) `\pdfoptionpdfminorversion` to set the  PDF version to 1.6.

- Also remove invisible whitespace at ends of lines.

- Closes #22.